### PR TITLE
Updated IDL based on Face to Face discussions

### DIFF
--- a/lighting-estimation-explainer.md
+++ b/lighting-estimation-explainer.md
@@ -39,7 +39,7 @@ HDR Cube Map textures are commonly used to implement "Reflection Probes" in mode
 
 SH (Spherical Harmonics) are used as a more compact alternative to HDR cube maps by storing a small number of coefficient values describing a fourier series over the surface of a sphere.  SH can effectively compress cube maps, while retaining multiple lights and directionality.  Due to their lightweight nature, many SH probes can be used within a scene, be interpolated, or be calculated for locations nearer to the lit objects.
 
-WebXR API supports up to 9 SH coefficients per RGB color component, for a total of 27 floating point scalar values.  This enables the level 2 (3rd) order of details.  If a platform can not supply all 9 coefficients, it can pass 0 for the higher order coefficients resulting in an effectively lower frequency reproduction.  
+WebXR API supports up to 9 SH coefficients per RGB color component, for a total of 27 floating point scalar values.  This enables the level 2 (3rd) order of details.  If a platform can not supply all 9 coefficients, it can pass 0 for the higher order coefficients resulting in an effectively lower frequency reproduction.
 
 This "SH probe" format is used by most modern rendering engines, including Unity, Unreal, and Threejs.
 
@@ -95,19 +95,25 @@ Filtered values MUST be first quantized before the box-kernel is applied.  Any v
 This is a partial IDL and is considered additive to the core IDL found in the main [explainer](explainer.md).
 
 ```webidl
+partial interface XRSession {
+  Promise<XRLightProbe> requestLightProbe();
+}
+
 partial interface XRFrame {
-  XRLightProbe? globalLightProbe;
+  XRLightEstimate? getLightEstimate(XRLightProbe lightProbe);
 };
 
 [SecureContext, Exposed=Window]
 partial interface XRLightProbe : EventTarget {
   readonly attribute XRSpace probeSpace;
+  attribute EventHandler onreflectionchange;
+};
+
+[SecureContext, Exposed=Window]
+partial interface XRLightEstimate {
   readonly attribute Float32Array sphericalHarmonicsCoefficients;
   readonly attribute DOMPointReadOnly primaryLightDirection;
   readonly attribute DOMPointReadOnly primaryLightIntensity;
-
-  // Events
-  attribute EventHandler onreflectionchange;
 };
 
 partial interface XRWebGLLayerFactory {

--- a/lighting-estimation-explainer.md
+++ b/lighting-estimation-explainer.md
@@ -96,22 +96,24 @@ This is a partial IDL and is considered additive to the core IDL found in the ma
 
 ```webidl
 partial interface XRFrame {
-  Promise<XRLightProbe> getGlobalLightEstimate();
-  Promise<XRReflectionProbe> getGlobalReflectionProbe();
+  XRLightProbe? globalLightProbe;
 };
 
 [SecureContext, Exposed=Window]
-partial interface XRLightProbe {
-  readonly attribute Float32Array indirectIrradiance;
-  readonly attribute Float32Array? primaryLightDirection;
-  readonly attribute Float32Array? primaryLightIntensity;
-  readonly attribute Float32Array? sphericalHarmonicsCoefficients;
-  [SameObject] readonly attribute DOMPointReadOnly? sphericalHarmonicsOrientation;
+partial interface XRLightProbe : EventTarget {
+  readonly attribute XRSpace probeSpace;
+  readonly attribute Float32Array sphericalHarmonicsCoefficients;
+  readonly attribute DOMPointReadOnly primaryLightDirection;
+  readonly attribute DOMPointReadOnly primaryLightIntensity;
+
+  // Events
+  attribute EventHandler onreflectionchange;
 };
 
-[SecureContext, Exposed=Window]
-partial interface XRReflectionProbe {
-  [SameObject] readonly attribute DOMPointReadOnly orientation;
-  WebGLTexture? createWebGLEnvironmentCube();
+partial interface XRWebGLLayerFactory {
+  // See https://github.com/immersive-web/layers for definition.
+  // Using it in this way may justify a name change, since it
+  // would no longer just be for layer management.
+
+  WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe);
 };
-```


### PR DESCRIPTION
This PR is mostly to facilitate discussion around the potential interface. The rest of the explainer would still need to be updated to account for this change if we accepted it, but I didn't want to sink any time into it until I knew we were in agreement about the API shape.

Some things to highlight:

One of the reasons it's taken me so long to post this is because I wanted to see where some of the [layers](https://github.com/immersive-web/layers) discussions would go, and it's looking like those are solidifying. The result is that I think we should use a concept that the layers API is introducing currently called the `XRWebGLLayerFactory`, but which we'd probably want to rename to something more generic if we used it here. The idea being that it's an object separate from the `XRSession` which is completely responsible for any Session<->Graphics API interaction. (This keeps the API interface clean for when we want to introduce WebGPU support.) While layers are the most obvious use case, I think we should use it here for surfacing the reflection cube maps. This has the advantage of implicitly tying it to a specific WebGL context, which simplifies the resource management significantly.

Next, as we discussed at the F2F we need to be able to properly orient our lighting information. While using a space here feels a bit heavyweight, given that we're mostly concerned with orientation, it does allow us to reuse a fundamental part of the spec and offers more flexibility down the road if we start supporting multiple light probes, so it feels appropriate.

Now, since we've moved the cube map creation off to a different interface entirely and we have a space available for the orientation, it no longer feels like we need a unique interface for a reflection probe? So it seems like a nice simplification to have everything key off the single `XRLightProbe` interface. Even if we decide to allow SH/Directional to be enabled separately from the reflection probe we'd simply always have the cube map function return `null` when you pass the probe to it. The one thing that could throw that off is if the reflection probe and SH/directional information somehow had to have different spaces/orientations. That's not true of either of the current native APIs, though.

We do still want to know when the cube map updates, though, since that's potentially expensive to process, so we'd want an `reflectionchange` event on the `XRLightProbe`.

Finally, the `primaryLightDirection` has been changed to `DOMPoint`s to stay in sync with vector representations elsewhere in the API. Using `DOMPoint` for the `primaryLightIntensity` is a little bit weirder, but it seemed appropriate? I'm not too attached to it either way. Also worth noting that none of the `XRLightProbe` attributes are nullable while the `globabLightProbe` itself is. This is because we can use the presence of the `globalLightProbe` to communicate whether lighting information is available at all, but once you have it everything else seems like it has reasonable defaults or sane ways to communicate less accurate information. For example: `primaryLight___` can fall back to straight down and black.

Thoughts?