### PR TITLE
First pass at defining the various attributes exposed by this module

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -105,6 +105,10 @@ interface XRLightProbe : EventTarget {
 };
 </pre>
 
+The <dfn attribute for="XRLightProbe">probeSpace</dfn> attribute is an {{XRSpace}} that has a [=native origin=] tracking the position and orientation that the {{XRLightProbe}}'s lighting estimations are being generated relative to.
+
+The <dfn attribute for="XRLightProbe">onreflectionchange</dfn> attribute is an [=Event handler IDL attribute=] for the {{reflectionchange}} event type.
+
 XRLightEstimate {#xrlightestimate-interface}
 ------------
 
@@ -118,6 +122,12 @@ interface XRLightEstimate {
   readonly attribute DOMPointReadOnly primaryLightIntensity;
 };
 </pre>
+
+The <dfn attribute for="XRLightEstimate">sphericalHarmonicsCoefficients</dfn> attribute returns a {{Float32Array}} containing 9 spherical harmonics coefficients. The array MUST be 27 elements in length, with every 3 elements defining the red, green, and blue components respectively of a single coefficient. The first term of the {{XRLightEstimate/sphericalHarmonicsCoefficients}}, meaning the first 3 elements of the array, MUST be representative of a valid lighting estimate. All other terms are optional, and MAY be 0 if a corresponding lighting estimate is not available due to either user privacy settings or the capabilities of the platform.
+
+The <dfn attribute for="XRLightEstimate">primaryLightDirection</dfn> represents the direction to the primary light source from the [=native origin=] of the {{XRLightProbe/probeSpace}} of the {{XRLightProbe}} that produced the {{XRLightEstimate}}. The value MUST be a unit length 3D vector and the {{DOMPointReadOnly/w}} value MUST be <code>0.0</code>. If estimated values from the users's environment are not available the {{XRLightEstimate/primaryLightDirection}} MUST be <code>{ x: 0.0, y: 1.0, z: 0.0, w: 0.0 }</code>, representing a light shining straight down from above.
+
+The <dfn attribute for="XRLightEstimate">primaryLightIntensity</dfn> represents the direction to the primary light source from the origin of the {{XRLightProbe/probeSpace}} of the {{XRLightProbe}} that produced the {{XRLightEstimate}}. The value MUST represent an RGB value mapped to the {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} values respectively where each component is greater than or equal to <code>0.0</code> and the {{DOMPointReadOnly/w}} value MUST be <code>1.0</code>. If estimated values from the users's environment are not available the {{XRLightEstimate/primaryLightIntensity}} MUST be <code>{x: 0.0, y: 0.0, z: 0.0, w: 1.0}</code>, representing no illumination.
 
 WebXR Device API Integration {#webxr-device-api-integration}
 ============================
@@ -166,3 +176,13 @@ partial interface XRWebGLBinding {
   WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe);
 };
 </pre>
+
+Events {#events}
+======
+
+The [=task source=] for all [=tasks queued|queue a task=] in this specification is the <dfn>XR task source</dfn>, unless otherwise specified.
+
+Event Types {#event-types}
+-----------
+
+The user agent MUST fire a <dfn event for="XRLightProbe">reflectionchange</dfn> event on an {{XRLightProbe}} object each time the contents of the cube map returned by calling {{XRWebGLBinding/getReflectionCubeMap()}} have changed. The event MUST be of type {{Event}}.


### PR DESCRIPTION
Follow up to #30. Puts some initial definitions of the attributes in place. Some of the basic terms used here (like spherical harmonics) will need deeper definitions down the line.