### PR TITLE
Document reflection cube map format handling

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -101,45 +101,42 @@ An {{XRLightProbe}} collects estimated lighting information at a given point in 
 [SecureContext, Exposed=Window]
 interface XRLightProbe : EventTarget {
   readonly attribute XRSpace probeSpace;
-  readonly attribute XRReflectionCubeMapFormat preferredReflectionCubeMapFormat;
   attribute EventHandler onreflectionchange;
 };
 </pre>
 
 The <dfn attribute for="XRLightProbe">probeSpace</dfn> attribute is an {{XRSpace}} that has a [=native origin=] tracking the position and orientation that the {{XRLightProbe}}'s lighting estimations are being generated relative to.
 
-The <dfn attribute for="XRLightProbe">preferredReflectionCubeMapFormat</dfn> attribute is an {{XRReflectionCubeMapFormat}} enum that indicates the most efficient format for reflection cube maps to be returned in for this probe.
-
 The <dfn attribute for="XRLightProbe">onreflectionchange</dfn> attribute is an [=Event handler IDL attribute=] for the {{reflectionchange}} event type.
 
-XRReflectionCubeMapFormat {#xrreflectioncubemapformat-interface}
+XRReflectionFormat {#xrreflectionformat-interface}
 ------------
 <pre class="idl">
-enum XRReflectionCubeMapFormat {
+enum XRReflectionFormat {
   "srgba8",
   "rgba16f",
 };
 </pre>
 
-Reflection cube maps have an internal format that indicates how the texture data is represented, and may change how applications choose to use the texture. Cube maps MAY be requested with the {{XRReflectionCubeMapFormat/"srgba8"}} format or the {{XRLightProbe/preferredReflectionCubeMapFormat}} of the light probe.
+Reflection cube maps have an internal reflection format that indicates how the texture data is represented, and may change how applications choose to use the texture. Cube maps MAY be requested with the {{XRReflectionFormat/"srgba8"}} format or the {{XRSession/preferredReflectionFormat}} of the light probe.
 
 <table class='data'>
     <thead>
         <tr>
-            <th>{{XRReflectionCubeMapFormat}}
+            <th>{{XRReflectionFormat}}
             <th>WebGL Format
             <th>WebGL Internal Format
             <th>WebGPU Format
             <th>HDR
     </thead>
     <tr>
-        <td>{{XRReflectionCubeMapFormat/"srgba8"}}
+        <td>{{XRReflectionFormat/"srgba8"}}
         <td>RGBA
         <td>SRGB8_ALPHA8
         <td>"rgba8unorm-srgb"
         <td>
     <tr>
-        <td>{{XRReflectionCubeMapFormat/"rgba16f"}}
+        <td>{{XRReflectionFormat/"rgba16f"}}
         <td>RGBA
         <td>RGBA16F
         <td>"rgba16float"
@@ -184,8 +181,13 @@ XRSession {#xrsession-interface}
 The {{XRSession}} interface is extended with the ability to create new {{XRLightProbe}} instances.
 
 <pre class="idl">
+dictionary XRLightProbeInit {
+  XRReflectionFormat reflectionFormat = "srgba8";
+};
+
 partial interface XRSession {
-  Promise&lt;XRLightProbe&gt; requestLightProbe();
+  Promise&lt;XRLightProbe&gt; requestLightProbe(optional XRLightProbeInit options = {});
+  readonly attribute XRReflectionFormat preferredReflectionFormat;
 };
 </pre>
 
@@ -212,7 +214,7 @@ The {{XRWebGLBinding}} interface is extended with the ability to query a reflect
 
 <pre class="idl">
 partial interface XRWebGLBinding {
-  WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe, XRReflectionCubeMapFormat format="srgba8");
+  WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe);
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -101,13 +101,50 @@ An {{XRLightProbe}} collects estimated lighting information at a given point in 
 [SecureContext, Exposed=Window]
 interface XRLightProbe : EventTarget {
   readonly attribute XRSpace probeSpace;
+  readonly attribute XRReflectionCubeMapFormat preferredReflectionCubeMapFormat;
   attribute EventHandler onreflectionchange;
 };
 </pre>
 
 The <dfn attribute for="XRLightProbe">probeSpace</dfn> attribute is an {{XRSpace}} that has a [=native origin=] tracking the position and orientation that the {{XRLightProbe}}'s lighting estimations are being generated relative to.
 
+The <dfn attribute for="XRLightProbe">preferredReflectionCubeMapFormat</dfn> attribute is an {{XRReflectionCubeMapFormat}} enum that indicates the most efficient format for reflection cube maps to be returned in for this probe.
+
 The <dfn attribute for="XRLightProbe">onreflectionchange</dfn> attribute is an [=Event handler IDL attribute=] for the {{reflectionchange}} event type.
+
+XRReflectionCubeMapFormat {#xrreflectioncubemapformat-interface}
+------------
+<pre class="idl">
+enum XRReflectionCubeMapFormat {
+  "srgba8",
+  "rgba16f",
+};
+</pre>
+
+Reflection cube maps have an internal format that indicates how the texture data is represented, and may change how applications choose to use the texture. Cube maps MAY be requested with the {{XRReflectionCubeMapFormat/"srgba8"}} format or the {{XRLightProbe/preferredReflectionCubeMapFormat}} of the light probe.
+
+<table class='data'>
+    <thead>
+        <tr>
+            <th>{{XRReflectionCubeMapFormat}}
+            <th>WebGL Format
+            <th>WebGL Internal Format
+            <th>WebGPU Format
+            <th>HDR
+    </thead>
+    <tr>
+        <td>{{XRReflectionCubeMapFormat/"srgba8"}}
+        <td>RGBA
+        <td>SRGB8_ALPHA8
+        <td>"rgba8unorm-srgb"
+        <td>
+    <tr>
+        <td>{{XRReflectionCubeMapFormat/"rgba16f"}}
+        <td>RGBA
+        <td>RGBA16F
+        <td>"rgba16float"
+        <td>&checkmark;
+</table>
 
 XRLightEstimate {#xrlightestimate-interface}
 ------------
@@ -175,7 +212,7 @@ The {{XRWebGLBinding}} interface is extended with the ability to query a reflect
 
 <pre class="idl">
 partial interface XRWebGLBinding {
-  WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe);
+  WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe, XRReflectionCubeMapFormat format="srgba8");
 };
 </pre>
 

--- a/lighting-estimation-explainer.md
+++ b/lighting-estimation-explainer.md
@@ -129,6 +129,12 @@ lightProbe.addEventListener('reflectionchange', () => {
 });
 ```
 
+By default the cube map will be returned as a 8BPP sRGB texture. Some underlying runtimes may deliver the text data in a different "native" format however, such high dynamic range formats. The light probe's preferred internal format is reported by the `XRLightProbe.preferredReflectionCubeMapFormat`, which may alternately be specified when querying the cube map. Querying the cube map using the preferred format ensures the minimal amount of conversion needs to happen, which in turn may be faster and experience less data loss. PAssing any value other than `"srgb8"` or the light probe's `preferredReflectionCubeMapFormat` to `getReflectionCubeMap()` will cause a `null` texture to be returned.
+
+```js
+let glCubeMap = glBinding.getReflectionCubeMap(lightProbe, lightProbe.preferredReflectionCubeMapFormat);
+```
+
 UA's may provide real-time reflection cube maps, captured by cameras or other sensors reporting high frequency spatial information. To access such real-time cube maps, the `camera` feature policy must be enabled for the origin. `XRWebGLBinding.getReflectionCubeMap()` should only return real-time cube maps following user consent equivalent to requesting access to the camera.
 
 UA's may provide a reflection cube map that was pre-created by the end user, which may differ from the environment while the `XRSession` is active. In particular, the user may choose to manually capture a reflection cube map at an earlier time when sensitive information or people are not present in the environment.
@@ -163,9 +169,15 @@ partial interface XRFrame {
   XRLightEstimate? getLightEstimate(XRLightProbe lightProbe);
 };
 
+enum XRReflectionCubeMapFormat {
+  "srgb8",
+  "hdr16f",
+};
+
 [SecureContext, Exposed=Window]
 partial interface XRLightProbe : EventTarget {
   readonly attribute XRSpace probeSpace;
+  readonly attribute XRReflectionCubeMapFormat preferredReflectionCubeMapFormat;
   attribute EventHandler onreflectionchange;
 };
 
@@ -178,6 +190,6 @@ partial interface XRLightEstimate {
 
 // See https://github.com/immersive-web/layers for definition.
 partial interface XRWebGLBinding {
-  WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe);
+  WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe, XRReflectionCubeMapFormat format="srgb8");
 };
 ```

--- a/lighting-estimation-explainer.md
+++ b/lighting-estimation-explainer.md
@@ -141,7 +141,6 @@ UA's may provide a reflection cube map that was pre-created by the end user, whi
 
 #### Cube Map Open Questions:
   - Is there a size tolerance for the cube maps re: user consent? ARCore's cube maps are limited to 16px per side, which seems difficult to get sensitive information out of.
-  - Should/can we dictate the format the cube maps return in. ARCore prefers Half Float values, which is hard for WebGL 1 compatibility and cubemap gen. No idea what format ARKit's textures are in.
   - Should we handle mipmapping for the user. My gut and ARCore says no, but I'm not sure what ARKit does here either.
   - Should we allow for a single texture to be returned multiple times? Seems potentially fragile but may incur unnecessary readback on iOS.
 
@@ -170,8 +169,8 @@ partial interface XRFrame {
 };
 
 enum XRReflectionCubeMapFormat {
-  "srgb8",
-  "hdr16f",
+  "srgba8",
+  "rgba16f",
 };
 
 [SecureContext, Exposed=Window]

--- a/lighting-estimation-explainer.md
+++ b/lighting-estimation-explainer.md
@@ -129,7 +129,7 @@ lightProbe.addEventListener('reflectionchange', () => {
 });
 ```
 
-By default the cube map will be returned as a 8BPP sRGB texture. Some underlying runtimes may deliver the text data in a different "native" format however, such high dynamic range formats. The light probe's preferred internal format is reported by the `XRLightProbe.preferredReflectionCubeMapFormat`, which may alternately be specified when querying the cube map. Querying the cube map using the preferred format ensures the minimal amount of conversion needs to happen, which in turn may be faster and experience less data loss. PAssing any value other than `"srgb8"` or the light probe's `preferredReflectionCubeMapFormat` to `getReflectionCubeMap()` will cause a `null` texture to be returned.
+By default the cube map will be returned as a 8BPP sRGB texture. Some underlying runtimes may deliver the text data in a different "native" format however, such high dynamic range formats. The light probe's preferred internal format is reported by the `XRLightProbe.preferredReflectionCubeMapFormat`, which may alternately be specified when querying the cube map. Querying the cube map using the preferred format ensures the minimal amount of conversion needs to happen, which in turn may be faster and experience less data loss. Passing any value other than `"srgb8"` or the light probe's `preferredReflectionCubeMapFormat` to `getReflectionCubeMap()` will cause a `null` texture to be returned.
 
 ```js
 let glCubeMap = glBinding.getReflectionCubeMap(lightProbe, lightProbe.preferredReflectionCubeMapFormat);


### PR DESCRIPTION
Fixes #33

One significant change I made from the discussion there is stating in the explainer that while sRGB is supported everywhere the only other valid format is whatever the system lists as it's preferred format. The will prevent the need to implement any conversion at all for a runtime like Apple's and only require a single conversion path for a runtime like ARCore, even if we expand the number of possible formats in the future.

I know @kearwood is no longer with Mozilla and thus may not have any time or motivation to review this, but if you have any thought's I'd appreciate them!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/lighting-estimation/pull/36.html" title="Last updated on Nov 3, 2020, 9:43 PM UTC (9a1103f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/lighting-estimation/36/8591735...9a1103f.html" title="Last updated on Nov 3, 2020, 9:43 PM UTC (9a1103f)">Diff</a>