### PR TITLE
Clarify steps for getReflectionCubeMap

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,12 @@ spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
     type: dfn; text: XR device; url: xr-device
     type: dfn; text: XR task source; url: xr-task-source
 
+spec: WebXR Layers API; urlPrefix: https://immersive-web.github.io/layers/#
+    type: interface; text: XRWebGLBinding; url: xrwebglbinding
+    for: XRWebGLBinding;
+        type: dfn; text: context; url: xrwebglbinding-context
+        type: dfn; text: session; Url: xrwebglbinding-session
+
 urlPrefix: https://www.w3.org/TR/ambient-light/; spec: AMBIENT-LIGHT
     type: dfn; text: privacy and security risks; url: security-and-privacy
 </pre>
@@ -298,6 +304,19 @@ partial interface XRWebGLBinding {
   WebGLTexture? getReflectionCubeMap(XRLightProbe lightProbe);
 };
 </pre>
+
+<div class="algorithm" data-algorithm="get-reflection-cubemap">
+When the <dfn method for="XRWebGLBinding">getReflectionCubeMap(|lightProbe|)</dfn> method is invoked on {{XRWebGLBinding}} |binding|, the user agent MUST run the following steps:
+
+  1. If |binding|'s [=XRWebGLBinding/context=] is lost, throw an {{InvalidStateError}} and abort these steps.
+  1. Let |session| be |binding|'s [=XRWebGLBinding/session=].
+  1. If |session| is ended, throw an {{InvalidStateError}} and abort these steps.
+  1. If |session| does not match |lightProbe|'s [=XRLightProbe/session=], throw an {{InvalidStateError}} and abort these steps.
+  1. Let |device| be |session|'s [=XRSession/XR Device=].
+  1. If no reflection cube map is available from |device|, return <code>null</code>.
+  1. Return a new {{WebGLTexture}} cubemap in the format specified by |lightProbe|'s [=XRLightProbe/reflection format=] and populated with the data from |device|.
+
+</div>
 
 Events {#events}
 ======


### PR DESCRIPTION
Adds algorithmic steps for getReflectionCubeMap. This is mainly added to clarify scenarios where getReflectionCubeMap may throw or otherwise return a null object.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alcooper91/lighting-estimation/pull/44.html" title="Last updated on Feb 9, 2021, 9:57 PM UTC (1b14058)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/lighting-estimation/44/72ab969...alcooper91:1b14058.html" title="Last updated on Feb 9, 2021, 9:57 PM UTC (1b14058)">Diff</a>