### PR TITLE
updated lines for CG-to-WG (draft, not for merge now)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,9 +1,9 @@
 <pre class="metadata">
-Shortname: webxrlightingestimation-1
+Shortname: webxr-lighting-estimation-1
 Title: WebXR Lighting Estimation API Level 1
 Group: immersivewebwg
 Status: ED
-TR:
+TR: https://www.w3.org/TR/webxr-lighting-estimation-1/
 ED: https://immersive-web.github.io/lighting-estimation/
 Repository: immersive-web/lighting-estimation
 Level: 1

--- a/index.bs
+++ b/index.bs
@@ -2,13 +2,12 @@
 Shortname: webxrlightingestimation-1
 Title: WebXR Lighting Estimation API Level 1
 Group: immersivewebwg
-Status: w3c/ED
+Status: ED
 TR:
-ED:
-Previous Version:
+ED: https://immersive-web.github.io/lighting-estimation/
 Repository: immersive-web/lighting-estimation
 Level: 1
-Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web/
+Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web-wg/
 
 Editor: Brandon Jones, Google https://google.com, bajones@google.com
 Editor: Kearwood Gilbert, Mozilla https://mozilla.org/, kgilbert@mozilla.com

--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
-    "group":      [87846]
-,   "contacts":   ["cwilso"]
-,   "repo-type":  "cg-report"
+    "group":      109735
+,   "contacts":   [ "himorin" ]
+,   "repo-type":  "rec-track"
 }


### PR DESCRIPTION
Resolution: https://lists.w3.org/Archives/Public/public-immersive-web-wg/2021Aug/0029.html

@toji is it ok to keep current shortname without '-', or align with others like [webxr-depth-sensing-1](https://www.w3.org/TR/2021/WD-webxr-depth-sensing-1-20210831/) or [webxr-hit-test-1](https://www.w3.org/TR/2021/WD-webxr-hit-test-1-20210831/) /cc @AdaRoseCannon @Yonet @cwilso


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/immersive-web-lighting-estimation/pull/51.html" title="Last updated on Sep 2, 2021, 4:38 AM UTC (0b845d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/lighting-estimation/51/d51d736...himorin:0b845d3.html" title="Last updated on Sep 2, 2021, 4:38 AM UTC (0b845d3)">Diff</a>