### PR TITLE
Fix xrsession refs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -34,7 +34,7 @@ spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
         type: dfn; text: native origin; url: xrspace-native-origin
     type: interface; text: XRSession; url: xrsession-interface
     for: XRSession;
-        type: dfn; text: ended; url: ended
+        type: attribute; text: ended; url: xrsession-ended
         type: dfn; text: list of enabled features; url: xrsession-list-of-enabled-features
         type: dfn; text: XR device; url: xrsession-xr-device
     type: interface; text: XRFrame; url: xrframe-interface
@@ -227,7 +227,7 @@ partial interface XRSession {
 When the <dfn method for="XRSession">requestLightProbe(|options|)</dfn> method is invoked on {{XRSession}} |session|, the user agent MUST run the following steps:
   1. Let |promise| be [=a new Promise=].
   1. If the [=light-estimation=] feature descriptor is not [=list/contain|contained=] in the |session|'s [=XRSession/list of enabled features=], [=/reject=] |promise| with {{NotSupportedError}} and abort these steps.
-  1. If |session|’s [=XRSession/ended=] value is <code>true</code>, throw an {{InvalidStateError}} and abort these steps.
+  1. If |session|’s {{XRSession/ended}} value is <code>true</code>, throw an {{InvalidStateError}} and abort these steps.
 
     <dl class="switch">
       <dt>If |options|'s {{XRLightProbeInit/reflectionFormat}} is {{XRReflectionFormat/"srgba8"}} or matches |session|'s {{XRSession/preferredReflectionFormat}}:</dt>
@@ -313,7 +313,7 @@ When the <dfn method for="XRWebGLBinding">getReflectionCubeMap(|lightProbe|)</df
 
   1. If |binding|'s [=XRWebGLBinding/context=] is lost, throw an {{InvalidStateError}} and abort these steps.
   1. Let |session| be |binding|'s [=XRWebGLBinding/session=].
-  1. If |session| is ended, throw an {{InvalidStateError}} and abort these steps.
+  1. If |session|’s {{XRSession/ended}} value is <code>true</code>, throw an {{InvalidStateError}} and abort these steps.
   1. If |session| does not match |lightProbe|'s [=XRLightProbe/session=], throw an {{InvalidStateError}} and abort these steps.
   1. Let |device| be |session|'s [=XRSession/XR Device=].
   1. If no reflection cube map is available from |device|, return <code>null</code>.

--- a/index.bs
+++ b/index.bs
@@ -20,8 +20,6 @@ Abstract: This specification describes support for exposing estimates of environ
 </pre>
 
 <pre class="link-defaults">
-spec: webxr-1;
-    type: dfn; text: feature descriptor
 spec:webidl; type:dfn; text:resolve
 </pre>
 


### PR DESCRIPTION
Fixes the references to XRSession/ended providing Bikeshed link errors by attempting to link with a css spec. Further removes an extraneous link-default that appears to be unneeded and was causing a link error.

Makes on algorithm tweak by replacing some language with more formal language with links with the exact same meaning. (Adding links/proper boolean check to the statement "If session is ended"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/lighting-estimation/pull/64.html" title="Last updated on Dec 11, 2025, 9:41 PM UTC (cf2ba92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/lighting-estimation/64/3b1749e...cf2ba92.html" title="Last updated on Dec 11, 2025, 9:41 PM UTC (cf2ba92)">Diff</a>